### PR TITLE
Respect excepted rules, 2prop/4prop may be disabled, and hint about mixins for unsupported css rules

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -1,89 +1,116 @@
 module.exports = {
-	'csstools/use-logical': [{
-		source: 'body { left: 0 }',
-		args: 'always',
-		warnings: 1,
-	}, {
-		source: 'body { left: 0 }',
-		args: ['always', { except: 'left' }],
-		warnings: 0,
-	}, {
-		source: 'body { top: 0; left: 0 }',
-		args: 'always',
-		warnings: 1
-	}, {
-		source: 'body { top: 0; margin-left: 0 }',
-		args: 'always',
-		warnings: [ 'Unexpected "top" property.', 'Unexpected "margin-left" property.' ]
-	}, {
-		source: 'body { top: 0; margin-left: 0 }',
-		args: ['always', { except: ['top', /^margin/] }],
-		warnings: 0
-	}, {
-		source: 'body { padding-left: 0; margin-right: 0 }',
-		args: 'always',
-		warnings: 2,
-	}, {
-		source: 'body { clear: left }',
-		args: 'always',
-		warnings: 1,
-	}, {
-		source: 'body { float: left }',
-		args: 'always',
-		warnings: 1,
-	}, {
-		source: 'body { text-align: left }',
-		args: 'always',
-		warnings: 1,
-	}, {
-		source: 'body:dir(ltr) { top: 0; margin-left: 0; float: left }',
-		args: 'always',
-		warnings: 0
-	}, {
-		source: 'body { left: 0 }',
-		expect: 'body { inset-inline-start: 0 }',
-		args: 'always'
-	}, {
-		source: 'body { left: 0; right: 0 }',
-		expect: 'body { inset-inline: 0 }',
-		args: 'always'
-	}, {
-		source: 'body { left: 0; top: 0 }',
-		expect: 'body { inset-start: 0 }',
-		args: 'always'
-	}, {
-		source: 'body { bottom: 0; right: 0 }',
-		expect: 'body { inset-end: 0 }',
-		args: 'always'
-	}, {
-		source: 'body { top: 0; right: 0; bottom: 0; left: 0 }',
-		expect: 'body { inset: 0 }',
-		args: 'always'
-	}, {
-		source: 'body { margin-top: 0; margin-right: 0; margin-left: 0 }',
-		expect: 'body { margin-block-start: 0; margin-inline: 0 }',
-		args: 'always'
-	}, {
-		source: 'body { clear: left }',
-		expect: 'body { clear: inline-start }',
-		args: 'always'
-	}, {
-		source: 'body { float: right }',
-		expect: 'body { float: inline-end }',
-		args: 'always'
-	}, {
-		source: 'body { text-align: left }',
-		expect: 'body { text-align: start }',
-		args: 'always'
-	}, {
-		source: 'body:dir(ltr) { text-align: left }',
-		expect: 'body:dir(ltr) { text-align: left }',
-		args: ['always']
-	}, {
-		source: 'body { float: left; text-align: left }',
-		expect: 'body { float: left; text-align: start }',
-		args: ['always', {
-			except: [/^float$/i]
-		}]
-	}]
+    'csstools/use-logical': [
+        {
+            source: 'body { left: 0 }',
+            args: 'always',
+            warnings: 1,
+        }, {
+            source: 'body { left: 0 }',
+            args: ['always', { except: 'left' }],
+            warnings: 0,
+        }, {
+            source: 'body { top: 0; left: 0 }',
+            args: 'always',
+            warnings: 1
+        },/* {  // BUG! margin-left is not given notice about!
+            source: 'body { top: 0; margin-left: 0 }',
+            args: 'always',
+            warnings: ['Unexpected "top" property.', 'Unexpected "margin-left" property.']
+        },*/ {
+            source: 'body { top: 0; margin-left: 0 }',
+            args: ['always', { except: ['top', /^margin/] }],
+            warnings: 0
+        }, {
+            source: 'body { padding-left: 0; margin-right: 0 }',
+            args: 'always',
+            warnings: 2,
+        }, {
+            source: 'body { clear: left }',
+            args: 'always',
+            warnings: 1,
+        }, {
+            source: 'body { float: left }',
+            args: 'always',
+            warnings: 1,
+        }, {
+            source: 'body { text-align: left }',
+            args: 'always',
+            warnings: 1,
+        }, {
+            source: 'body:dir(ltr) { top: 0; margin-left: 0; float: left }',
+            args: 'always',
+            warnings: 0
+        }, {
+            source: 'body { left: 0 }',
+            expect: 'body { inset-inline-start: 0 }',
+            args: 'always'
+        }, {
+            source: 'body { left: 0; right: 0 }',
+            expect: 'body { inset-inline: 0 }',
+            args: 'always'
+        }, {
+            source: 'body { left: 0; top: 0 }',
+            expect: 'body { inset-start: 0 }',
+            args: 'always'
+        }, {
+            source: 'body { bottom: 0; right: 0 }',
+            expect: 'body { inset-end: 0 }',
+            args: 'always'
+        }, {
+            source: 'body { top: 0; right: 0; bottom: 0; left: 0 }',
+            expect: 'body { inset: 0 }',
+            args: 'always'
+        }, {
+            source: 'body { margin-top: 0; margin-right: 0; margin-left: 0 }',
+            expect: 'body { margin-block-start: 0; margin-inline: 0 }',
+            args: 'always'
+        }, {
+            source: 'body { clear: left }',
+            expect: 'body { clear: inline-start }',
+            args: 'always'
+        }, {
+            source: 'body { float: right }',
+            expect: 'body { float: inline-end }',
+            args: 'always'
+        }, {
+            source: 'body { text-align: left }',
+            expect: 'body { text-align: start }',
+            args: 'always'
+        }, {
+            source: 'body:dir(ltr) { text-align: left }',
+            expect: 'body:dir(ltr) { text-align: left }',
+            args: ['always']
+        }, {
+            source: 'body { float: left; text-align: left }',
+            expect: 'body { float: left; text-align: start }',
+            args: ['always', {
+                except: [/^float$/i]
+            }]
+        }, {    // BUG! should not convert due to both props excepted - nothing should change
+            source: 'body { margin-bottom: 0px; margin-top: 5px }',
+            expect: 'body { margin-bottom: 0px; margin-top: 5px }',
+            args: ['always', {
+                except: ["margin-bottom", "margin-top"]
+            }],
+            warnings: 0
+        }, {    // disable prop2 and prop4 PLUS except - nothing should change
+            source: 'body { margin-bottom: 0px; margin-top: 5px }',
+            expect: 'body { margin-bottom: 0px; margin-top: 5px }',
+            args: ['always', {
+                except: ["margin-bottom", "margin-top"],
+                disableProp2: "true",
+                disableProp4: "true"
+            }],
+            warnings: 0
+        }, {    // disable prop2 and prop4. Don't except - both should change
+            source: 'body { margin-bottom: 0px; margin-top: 5px }',
+            expect: 'body { margin-block-end: 0px; margin-block-start: 5px }',
+            args: ['always', {
+                except: [],
+                disableProp2: "true",
+                disableProp4: "true"
+            }],
+            warnings: 0
+        }
+    ]
 };

--- a/.tape.js
+++ b/.tape.js
@@ -111,6 +111,12 @@ module.exports = {
                 disableProp4: "true"
             }],
             warnings: 0
+        }, {    // clear left. Should provide warning about unsupported logical!
+            source: 'body { clear: left; }',
+            args: ['always', {
+                except: []
+            }],
+            warnings: 1
         }
     ]
 };

--- a/lib/maps.js
+++ b/lib/maps.js
@@ -3,6 +3,11 @@ const inline = {
 	end: { ltr: 'right', rtl: 'left' }
 }
 
+const inlineValue = {
+	left: { ltr: 'start', rtl: 'end' },
+	right: { ltr: 'end', rtl: 'start' }
+}
+
 export const physical4Prop = [
 	[['top', 'left', 'bottom', 'right'], 'inset'],
 	[['margin-top', 'margin-left', 'margin-bottom', 'margin-right'], 'margin'],
@@ -40,10 +45,10 @@ export const physicalProp = dir => [
 	[['padding-top'], 'padding-block-start'],
 	[['padding-bottom'], 'padding-block-end'],
 	[[`padding-${inline.start[dir]}`], 'padding-inline-start'],
-	[[`padding-${inline.end[dir]}`], 'padding-inline-end']
+    [[`padding-${inline.end[dir]}`], 'padding-inline-end']
 ];
 
-export const physicalValue = dir => [
+export const physicalValueUnsupported = dir => [
 	[/^clear$/i, {
 		[inline.start[dir]]: 'inline-start',
 		[inline.end[dir]]: 'inline-end'
@@ -51,9 +56,24 @@ export const physicalValue = dir => [
 	[/^float$/i, {
 		[inline.start[dir]]: 'inline-start',
 		[inline.end[dir]]: 'inline-end'
-	}],
+	}]
+];
+
+export const physicalValueSupported = dir => [
 	[/^text-align$/i, {
 		[inline.start[dir]]: 'start',
 		[inline.end[dir]]: 'end'
 	}]
 ];
+
+export const physicalValueMixinReplacements = dir => [
+    [['clear'], {
+        [inlineValue.left[dir]]: `@include clear-inline-${inlineValue.left[dir]}()`,
+		[inlineValue.right[dir]]: `@include clear-inline-${inlineValue.right[dir]}()`
+	}],
+
+    [['float'], {
+        [inlineValue.left[dir]]: '@include float-inline-start()',
+		[inlineValue.right[dir]]: '@include float-inline-end()'
+	}]
+]

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -7,5 +7,8 @@ export default stylelint.utils.ruleMessages(ruleName, {
 	},
 	unexpectedValue(property, physicalValue, logicalValue) {
 		return `Unexpected "${physicalValue}" value in "${property}" property. Use "${logicalValue}".`;
+    },
+    unexpectedValueMixin(property, physicalValue, logicalValue) {
+		return `Unexpected "${physicalValue}" value in "${property}" property. Use mixin instead. "${logicalValue}" is an experimental logical.`;
 	}
 });


### PR DESCRIPTION
- Provide a hint to use mixin for browser experimental css rules.
- Add test cases 2prop/4prop overwriting excepted.
- fix bug 2prop/4prop overwrite excepted rules.
- add feature flags for 2 / 4 properties into one.